### PR TITLE
Dedicated methods to check if file or if directory

### DIFF
--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -75,11 +75,12 @@ module Prawn
       return options.dup unless file?(src)
 
       path = Pathname.new(src)
-      options.dup.reverse_merge(
+
+      {
         name: File.basename(src),
         creation_date: creation_time(path),
         modification_date: path.mtime
-      )
+      }.merge(options.dup)
     end
 
     def file_obj_from_registry(file)

--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -39,7 +39,7 @@ module Prawn
     # hidden, then nil is returned.
     #
     def attach(src, options = {})
-      raise ArgumentError, "Data source can't be a directory" if is_directory?(src)
+      raise ArgumentError, "Data source can't be a directory" if directory?(src)
 
       data, opts = data_and_opts(src, options)
       file = EmbeddedFile.new(data, opts)
@@ -52,13 +52,13 @@ module Prawn
 
     private
 
-    def is_file?(path)
+    def file?(path)
       File.file?(path)
     rescue ArgumentError
       false
     end
 
-    def is_directory?(path)
+    def directory?(path)
       File.directory?(path)
     rescue ArgumentError
       false
@@ -66,7 +66,7 @@ module Prawn
 
     def data_and_opts(src, options)
       opts = options.dup
-      return [src, opts] unless is_file?(src)
+      return [src, opts] unless file?(src)
 
       path = Pathname.new(src)
       opts = {

--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -41,7 +41,8 @@ module Prawn
     def attach(src, options = {})
       raise ArgumentError, "Data source can't be a directory" if directory?(src)
 
-      data, opts = data_and_opts(src, options)
+      data = data_from_src(src)
+      opts = opts_from_src(src, options)
       file = EmbeddedFile.new(data, opts)
 
       filespec = Filespec.new(file_obj_from_registry(file), opts)
@@ -64,17 +65,21 @@ module Prawn
       File.directory?(path)
     end
 
-    def data_and_opts(src, options)
-      opts = options.dup
-      return [src, opts] unless file?(src)
+    def data_from_src(src)
+      return src unless file?(src)
+
+      Pathname.new(src).read.b
+    end
+
+    def opts_from_src(src, options = {})
+      return options.dup unless file?(src)
 
       path = Pathname.new(src)
-      opts = {
+      options.dup.reverse_merge(
         name: File.basename(src),
         creation_date: creation_time(path),
         modification_date: path.mtime
-      }.merge(opts)
-      [path.read, opts]
+      )
     end
 
     def file_obj_from_registry(file)

--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -53,15 +53,15 @@ module Prawn
     private
 
     def file?(path)
+      return false if path.include?("\u0000")
+
       File.file?(path)
-    rescue ArgumentError
-      false
     end
 
     def directory?(path)
+      return false if path.include?("\u0000")
+
       File.directory?(path)
-    rescue ArgumentError
-      false
     end
 
     def data_and_opts(src, options)

--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -68,6 +68,7 @@ module Prawn
       opts = options.dup
       return [src, opts] unless is_file?(src)
 
+      path = Pathname.new(src)
       opts = {
         name: File.basename(src),
         creation_date: creation_time(path),

--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -39,11 +39,9 @@ module Prawn
     # hidden, then nil is returned.
     #
     def attach(src, options = {})
-      path = Pathname.new(src)
+      raise ArgumentError, "Data source can't be a directory" if is_directory?(src)
 
-      raise ArgumentError, "Data source can't be a directory" if path.directory?
-
-      data, opts = data_and_opts(path, src, options)
+      data, opts = data_and_opts(src, options)
       file = EmbeddedFile.new(data, opts)
 
       filespec = Filespec.new(file_obj_from_registry(file), opts)
@@ -54,9 +52,21 @@ module Prawn
 
     private
 
-    def data_and_opts(path, src, options)
+    def is_file?(path)
+      File.file?(path)
+    rescue ArgumentError
+      false
+    end
+
+    def is_directory?(path)
+      File.directory?(path)
+    rescue ArgumentError
+      false
+    end
+
+    def data_and_opts(src, options)
       opts = options.dup
-      return [src, opts] unless path.file?
+      return [src, opts] unless is_file?(src)
 
       opts = {
         name: File.basename(src),

--- a/spec/prawn/attachment_spec.rb
+++ b/spec/prawn/attachment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Prawn::Attachment do
     expect do
       Prawn::Document.generate("hello.pdf") do
         text "Hello Spec!"
-        attach "./example/data.json"
+        attach "data.json", File.read("./example/data.json")
       end
     end.not_to raise_error
   end


### PR DESCRIPTION
This PR solves a bug that happens when the `src` parameter contains a null byte.