### PR TITLE
Support temp files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.5
+  Exclude:
+    - "spec"
 
 Style/StringLiterals:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.5
   Exclude:
-    - "spec"
+    - "spec/**/*"
 
 Style/StringLiterals:
   Enabled: true

--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -19,6 +19,7 @@ module Prawn
       end
     end
 
+    # Invalid data provided
     class InvalidDataError < StandardError
       def message
         "Source data must be an IO object or string"
@@ -48,16 +49,7 @@ module Prawn
     # hidden, then nil is returned.
     #
     def attach(name, src, opts = {})
-      if src.respond_to?(:read)
-        data = src.read
-      elsif src.respond_to?(:b)
-        data = src.b
-      else
-        raise InvalidDataError
-      end
-
-      raise NoDataError if data.length.zero?
-
+      data = extract_data_from_source(src)
       opts = prepare_options(name, opts)
 
       # Prepare embeddable representation of the source data
@@ -70,6 +62,19 @@ module Prawn
     end
 
     private
+
+    def extract_data_from_source(src)
+      if src.respond_to?(:read)
+        data = src.read
+      elsif src.respond_to?(:b)
+        data = src.b
+      else
+        raise InvalidDataError
+      end
+      raise NoDataError if data.length.zero?
+
+      data
+    end
 
     def prepare_options(name, opts)
       {

--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -19,6 +19,12 @@ module Prawn
       end
     end
 
+    class InvalidDataError < StandardError
+      def message
+        "Source data must be an IO object or string"
+      end
+    end
+
     # Attach a file's data to the document. File IO Objects are expected.
     #
     # Arguments:
@@ -42,7 +48,14 @@ module Prawn
     # hidden, then nil is returned.
     #
     def attach(name, src, opts = {})
-      data = src.is_a?(IO) ? src.read : src.b
+      if src.respond_to?(:read)
+        data = src.read
+      elsif src.respond_to?(:b)
+        data = src.b
+      else
+        raise InvalidDataError
+      end
+
       raise NoDataError if data.length.zero?
 
       opts = prepare_options(name, opts)

--- a/spec/prawn/attachment_spec.rb
+++ b/spec/prawn/attachment_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tempfile"
+
 RSpec.describe Prawn::Attachment do
   it "has a version number" do
     expect(Prawn::Attachment::VERSION).not_to be nil
@@ -14,6 +16,19 @@ RSpec.describe Prawn::Attachment do
     end.not_to raise_error
   end
 
+  it "attaches a temp file" do
+    expect do
+      Tempfile.create do |f|
+        f << File.read("./example/data.json")
+        f.rewind
+        Prawn::Document.generate("hello.pdf") do
+          text "Hello Spec!"
+          attach "data.json", f
+        end
+      end.not_to raise_error
+    end
+  end
+
   it "attaches a string" do
     expect do
       Prawn::Document.generate("hello.pdf") do
@@ -21,5 +36,14 @@ RSpec.describe Prawn::Attachment do
         attach "data.json", File.read("./example/data.json")
       end
     end.not_to raise_error
+  end
+
+  it "failes with junk" do
+    expect do
+      Prawn::Document.generate("hello.pdf") do
+        text "Hello Spec!"
+        attach "data.json", Object.new
+      end
+    end.to raise_error(Prawn::Attachment::InvalidDataError)
   end
 end


### PR DESCRIPTION
Previous version did not support attaching temp files. This fixes that by broadening out the expected interface to simply ensure the incoming attachment responds to either `read` or `b` (byte conversion for strings).