### PR TITLE
Add /AFRelationship and /Subtype to embedded files

### DIFF
--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -83,7 +83,8 @@ module Prawn
         modification_date: opts[:modified_at] || Time.now.utc,
         description: opts[:description],
         hidden: !!opts[:hidden],
-        relationship: opts[:relationship]
+        relationship: opts[:relationship],
+        mime_type: opts[:mime_type]
       }
     end
 

--- a/lib/prawn/attachment.rb
+++ b/lib/prawn/attachment.rb
@@ -82,7 +82,8 @@ module Prawn
         creation_date: opts[:created_at] || Time.now.utc,
         modification_date: opts[:modified_at] || Time.now.utc,
         description: opts[:description],
-        hidden: !!opts[:hidden]
+        hidden: !!opts[:hidden],
+        relationship: opts[:relationship]
       }
     end
 

--- a/lib/prawn/attachment/embedded_file.rb
+++ b/lib/prawn/attachment/embedded_file.rb
@@ -4,7 +4,7 @@ module Prawn
   module Attachment
     # EmbeddedFile represents a file to be embedded in the PDF.
     class EmbeddedFile
-      attr_reader :data, :creation_date, :modification_date, :checksum
+      attr_reader :data, :creation_date, :modification_date, :subtype, :checksum
 
       def initialize(data, options = {})
         @data = data
@@ -14,6 +14,8 @@ module Prawn
 
         @modification_date = options[:modification_date]
         @modification_date = Time.now.utc unless @modification_date.is_a?(Time)
+
+        @subtype = (options[:mime_type] || "application/octet-stream").to_sym
 
         @checksum = Digest::MD5.digest(data)
       end
@@ -35,7 +37,8 @@ module Prawn
             ModDate: modification_date,
             CheckSum: PDF::Core::LiteralString.new(checksum),
             Size: data.length
-          }
+          },
+          Subtype: subtype
         }
       end
     end

--- a/lib/prawn/attachment/filespec.rb
+++ b/lib/prawn/attachment/filespec.rb
@@ -20,6 +20,10 @@ module Prawn
         end
 
         @hidden = options[:hidden]
+
+        if options[:relationship]
+          @relationship = options[:relationship]
+        end
         @file = file
       end
 
@@ -36,12 +40,13 @@ module Prawn
         )
 
         obj.data[:Desc] = description if description
+        obj.data[:AFRelationship] = relationship if relationship
         obj
       end
 
       private
 
-      attr_reader :file, :description
+      attr_reader :file, :description, :relationship
     end
   end
 end

--- a/spec/prawn/attachment_spec.rb
+++ b/spec/prawn/attachment_spec.rb
@@ -46,4 +46,17 @@ RSpec.describe Prawn::Attachment do
       end
     end.to raise_error(Prawn::Attachment::InvalidDataError)
   end
+  
+  it "adds AF references" do
+    pdf = Prawn::Document.new do
+      text "Hello Spec!"
+      attach "data.json", File.open("./example/data.json")
+    end
+    
+    output = pdf.render
+    
+    expect(output).to match /\/AF 9 0 R/
+    expect(output).to match /9 0 obj\n\[8 0 R\]\nendobj/
+    expect(output).to match /8 0 obj\n<< \/Type \/Filespec/
+  end
 end


### PR DESCRIPTION
I'm working towards adding XML attachments with electronic invoices to PDFs in my rails app.

Trying to validate the generated PDFs, I found out I needed two things:

- The `/AFRelationship` entry describing the relationship of the attachment to the PDF (`/Alternative`, `/Data`,  `/Source`, `/Supplement`, `/Unspecified`)
- The MIME type of the attachment, via the entry `/Subtype`, e.g. `/text#2Fxml` (representation of `text/xml`; default is `application/octet-stream`)

I just added those to the options:

```rb
attach "factur-x.xml", File.open("./factur-x.xml"),
               {
                 description: "Factur-X/ZUGFeRD-Rechnung",
                 relationship: :Alternative,
                 mime_type: "text/xml",
               }
```

The `mime_type` string is automatically converted to a symbol.